### PR TITLE
Remove some bugs to prevent crash of the app

### DIFF
--- a/app/src/main/java/com/cheezycode/quotify/MainViewModel.kt
+++ b/app/src/main/java/com/cheezycode/quotify/MainViewModel.kt
@@ -25,7 +25,7 @@ class MainViewModel(val context: Context): ViewModel() {
 
     fun getQuote() = quoteList[index]
 
-    fun nextQuote() = quoteList[++index]
+    fun nextQuote() = quoteList[++index % quoteList.size()]
 
-    fun previousQuote() = quoteList[--index]
+    fun previousQuote() = quoteList[(--index + quoteList.size()) % quoteList.size()]
 }


### PR DESCRIPTION
The app will crash when we call the previousQuote() when index = 0. 
To remove the bug I have made the value of index never become negative and never exceeds the size of QuoteList.